### PR TITLE
Moving the part that adds the id to the title into a method

### DIFF
--- a/src/Model/Barcode.php
+++ b/src/Model/Barcode.php
@@ -183,4 +183,18 @@ class Barcode {
     {
         return static::$namedCodesBySlug;
     }
+
+    /**
+     * Add the id to all titles that are named in the list of codes
+     */
+    public function appendIdsToTitles(array $codes): array
+    {
+        foreach ($codes as &$details) {
+            if ($details['title'] !== $details['id']) {
+                // include id in title
+                $details['title'] .= ' [' . $details['id'] . ']';
+            }
+        }
+        return $codes;
+    }
 }

--- a/webroot/generate.php
+++ b/webroot/generate.php
@@ -77,12 +77,7 @@ if (empty($codes)) {
 }
 
 if ($showId) {
-    foreach ($codes as &$details) {
-        if ($details['title'] !== $details['id']) {
-            // include id in title
-            $details['title'] .= ' [' . $details['id'] . ']';
-        }
-    }
+    $codes = $barcode->appendIdsToTitles($codes);
 }
 
 $size = $_GET['size'] ?? 'small';


### PR DESCRIPTION
fixes #2 

When it was using `foreach ($codes as &$details)` it should have unset `$details` to avoid it overwriting the last entry of the array when that var is re-used further down.  Instead I figured it would be good to move that into a method instead so the loop is not inline.