### PR TITLE
Add exception and error handling

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -50,3 +50,10 @@ spl_autoload_register(function ($class) {
         require $file;
     }
 });
+
+/**
+ * Handle uncaught exceptions - this is a simple app, we use exceptions for any errors and let this display the error
+ */
+set_exception_handler(function (Throwable $exception) {
+    require BASE_DIR . 'templates/layout/error.php';
+});

--- a/src/Exception/BadRequestException.php
+++ b/src/Exception/BadRequestException.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types = 1);
+
+namespace Jonyo\MarioLego\Exception;
+
+class BadRequestException extends HttpException {
+    /**
+     * The message used in the header if the exception is not caught
+     *
+     * @var string
+     */
+    protected $httpHeaderMessage = 'Bad Request';
+
+    /**
+     * The HTTP code
+     *
+     * @var int
+     */
+    protected $code = 400;
+}

--- a/src/Exception/HttpException.php
+++ b/src/Exception/HttpException.php
@@ -1,0 +1,57 @@
+<?php declare(strict_types = 1);
+
+namespace Jonyo\MarioLego\Exception;
+
+use Exception;
+
+/**
+ * Exeption used for displaying errors if not caught, and using the applicable HTTP header
+ */
+abstract class HttpException extends Exception {
+    /**
+     * Template used for the header
+     */
+    protected const HEADER = '%s %d %s';
+
+    /**
+     * The HTTP code
+     *
+     * @var int
+     */
+    protected $code = 400;
+
+    /**
+     * The message used in the header if the exception is not caught
+     *
+     * @var string
+     */
+    protected $httpHeaderMessage = 'Bad Request';
+
+    /**
+     * Default message if none provided
+     *
+     * @var string
+     */
+    protected $message = 'Unknown HTTP Exception';
+
+    /**
+     * Get the http header message used in the header
+     */
+    final public function getHttpHeaderMessage(): string
+    {
+        return $this->httpHeaderMessage;
+    }
+
+    /**
+     * Get the full header to use for this exception
+     */
+    final public function getHttpHeader(): string
+    {
+        return sprintf(
+            static::HEADER,
+            $_SERVER["SERVER_PROTOCOL"] ?? 'HTTP/1.1',
+            $this->getCode(),
+            $this->getHttpHeaderMessage()
+        );
+    }
+}

--- a/src/Exception/InternalException.php
+++ b/src/Exception/InternalException.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types = 1);
+
+namespace Jonyo\MarioLego\Exception;
+
+class InternalException extends HttpException {
+    /**
+     * Default message if none provided
+     *
+     * @var string
+     */
+    protected $message = 'Internal Exception.';
+
+    /**
+     * The HTTP code
+     *
+     * @var int
+     */
+    protected $httpHeaderMessage = 'Internal Server Error';
+
+    /**
+     * The HTTP code
+     *
+     * @var int
+     */
+    protected $code = 500;
+}

--- a/src/Exception/InvalidColorException.php
+++ b/src/Exception/InvalidColorException.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types = 1);
+
+namespace Jonyo\MarioLego\Exception;
+
+class InvalidColorException extends BadRequestException {
+    /**
+     * Default message if none provided
+     *
+     * @var string
+     */
+    protected $message = 'Invalid color provided';
+}

--- a/src/Exception/InvalidIdException.php
+++ b/src/Exception/InvalidIdException.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types = 1);
+
+namespace Jonyo\MarioLego\Exception;
+
+class InvalidIdException extends BadRequestException {
+    /**
+     * Default message if none provided
+     *
+     * @var string
+     */
+    protected $message = 'Invalid ID Specified.';
+}

--- a/src/Exception/InvalidPatternException.php
+++ b/src/Exception/InvalidPatternException.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types = 1);
+
+namespace Jonyo\MarioLego\Exception;
+
+class InvalidPatternException extends BadRequestException {
+    /**
+     * Default message if none provided
+     *
+     * @var string
+     */
+    protected $message = 'Invalid pattern provided.';
+}

--- a/src/Exception/NotFoundException.php
+++ b/src/Exception/NotFoundException.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types = 1);
+
+namespace Jonyo\MarioLego\Exception;
+
+class NotFoundException extends HttpException {
+    /**
+     * Default message if none provided
+     *
+     * @var string
+     */
+    protected $message = 'Item not found.';
+
+    /**
+     * The message used in the header if the exception is not caught
+     *
+     * @var string
+     */
+    protected $httpHeaderMessage = 'Not Found';
+
+    /**
+     * The HTTP code
+     *
+     * @var int
+     */
+    protected $code = 404;
+}

--- a/templates/layout/error.php
+++ b/templates/layout/error.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * @var Throwable $exception
+ */
+
+use Jonyo\MarioLego\Exception\HttpException;
+
+if ($exception instanceof HttpException) {
+    header($exception->getHttpHeader());
+}
+?>
+<!doctype html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title><?= $exception->getCode() ?> Error</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" type="text/css" href="style.css">
+</head>
+<body>
+    <header class="header">
+        <a href="/" class="header__back">< Back</a>
+        <h1 class="header__title">OOPS!</h1>
+    </header>
+    <main class="main error" role="main">
+        <h1 class="error__title"><?= $exception->getCode() ?> Error:</h1>
+        <p class="error__message"><?= $exception->getMessage() ?></p>
+    </main>
+</body>

--- a/templates/repeat-barcode.php
+++ b/templates/repeat-barcode.php
@@ -1,7 +1,10 @@
 <?php declare(strict_types = 1);
+
+use Jonyo\MarioLego\Exception\InternalException;
+
 // requires $details
 if (empty($details['id'])) {
-    throw new Exception('Invalid barcode passed');
+    throw new InternalException('Invalid barcode passed');
 }
 $size = $size ?? 'small';
 $sizes = [
@@ -14,7 +17,7 @@ $sizes = [
     'large' => 108
 ];
 if (empty($sizes[$size])) {
-    throw new Exception('Invalid size');
+    throw new InternalException('Invalid size: ' . htmlspecialchars($size) . ' - must be small, medium, or large');
 }
 $repeat = $sizes[$size];
 

--- a/webroot/barcode.php
+++ b/webroot/barcode.php
@@ -1,14 +1,12 @@
 <?php declare(strict_types = 1);
 
+use Jonyo\MarioLego\Exception\InvalidIdException;
 use Jonyo\MarioLego\Model\Barcode;
 
 require '../bootstrap.php';
 
 $barcode = new Barcode();
 $id = (int)$_GET['id'] ?? 0;
-if ($id < 1) {
-    throw new Exception('Invalid id');
-}
 $pattern = $barcode->patternFromId($id);
 
 header('Content-Type: image/svg+xml');

--- a/webroot/style.css
+++ b/webroot/style.css
@@ -3,6 +3,9 @@
     --dark-teal: #0b3231;
     --light-teal: #a8ede9;
     --transparent-white: rgba(255, 255, 255, .8);
+    --red: #b1252c;
+    --light-red: #f4cbcd;
+    --dark-red: #4c1013;
 }
 
 /**
@@ -17,12 +20,23 @@ body {
     border-radius: 0 0 40% 40%;
     padding: 1rem;
     margin-bottom: 2rem;
+    position: relative;
 }
 
 @media print {
     .header {
         display: none;
     }
+}
+
+.header__back {
+    position: absolute;
+    left: 1rem;
+    top: 1rem;
+    color: var(--dark-teal);
+    text-decoration: none;
+    border: 1px solid var(--dark-teal);
+    border-radius: .2rem;
 }
 
 .header__title {
@@ -48,6 +62,26 @@ body {
 
 .hide {
     display: none;
+}
+
+/**
+ * Errors
+ */
+
+.error {
+    border: 2px solid var(--dark-red);
+    border-radius: .5rem;
+    padding: 1rem;
+    background-color: var(--light-red);
+}
+
+.error__title {
+    color: var(--red);
+    margin: 0;
+}
+
+.error__message {
+    color: var(--dark-red);
 }
 
 /**


### PR DESCRIPTION
Closes #5 

This adds some exception handling.  The app uses exceptions to display errors, we didn't need anything fancier than that for such a small app.  Any uncaught exceptions now display a page and add the appropriate HTTP header if it is one of the app's exceptions.  They all look something like this:

<img width="1097" alt="Screen Shot 2020-10-28 at 9 58 34 AM" src="https://user-images.githubusercontent.com/2767294/97454054-54e83600-1904-11eb-83e3-fd34cccbbce1.png">
