### PR TITLE
Move printing tip to generate page and stop auto printing

### DIFF
--- a/webroot/generate.php
+++ b/webroot/generate.php
@@ -103,11 +103,14 @@ $size = $_GET['size'] ?? 'small';
         <h1 class="header__title">Barcodes</h1>
     </header>
     <main class="main" role="main">
+        <p class="main__tip">
+            <strong>Printing Tip:</strong> Be sure to print with the <strong>highest quality</strong> possible for your
+            printer.  The barcode details are quite small so need to be printed at max quality to be scannable.
+            <br>
+            <button onclick="window.print();" class="print-button">Print</button>
+        </p>
         <?php foreach($codes as $details): ?>
             <?php template('repeat-barcode', compact('details', 'size')); ?>
         <?php endforeach; ?>
     </main>
-    <script>
-        window.print();
-    </script>
 </body>

--- a/webroot/index.php
+++ b/webroot/index.php
@@ -20,10 +20,6 @@ $named = $barcode->allNamed();
         <h1 class="header__title">Barcode Generator</h1>
     </header>
     <main class="main" role="main">
-        <p class="main__tip">
-            <strong>Tip:</strong> Be sure to print with the highest quality possible for your printer.  These Barcodes
-            are quite small and can get blurred together, or sometimes the color "dimmed" if quality is not set to max.
-        </p>
         <form action="generate.php">
             <label>
                 Type:

--- a/webroot/style.css
+++ b/webroot/style.css
@@ -61,6 +61,19 @@ body {
     margin: 0 0 2rem;
 }
 
+@media print {
+    .main__tip {
+        display: none;
+    }
+}
+
+.print-button {
+    display: block;
+    line-height: 1.5rem;
+    padding: .1rem 1rem;
+    margin: 1rem auto 0;
+}
+
 .hide {
     display: none;
 }


### PR DESCRIPTION
closes #10

This PR:
* move the print tip to the generate page
* Adds a print button in the tip box
* No longer auto print when page loads

<img width="704" alt="Screen Shot 2020-10-29 at 3 07 29 PM" src="https://user-images.githubusercontent.com/2767294/97626869-83473d80-19f8-11eb-87bc-635c8a701da6.png">
