### PR TITLE
Adding more size options and cleaning up styling for each size

### DIFF
--- a/src/Exception/InvalidSizeException.php
+++ b/src/Exception/InvalidSizeException.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types = 1);
+
+namespace Jonyo\MarioLego\Exception;
+
+class InvalidSizeException extends BadRequestException {
+    /**
+     * Default message if none provided
+     *
+     * @var string
+     */
+    protected $message = 'Invalid size provided.';
+}

--- a/templates/repeat-barcode.php
+++ b/templates/repeat-barcode.php
@@ -2,53 +2,40 @@
 
 use Jonyo\MarioLego\Exception\InternalException;
 
-// requires $details
+// requires $details $size
 if (empty($details['id'])) {
     throw new InternalException('Invalid barcode passed');
 }
-$size = $size ?? 'small';
-$sizes = [
-    // small = 1x1 images
-    'small' => 2,
-    // medium = 3x3 images
-    'medium' => 6,
-    // large = 9x16-ish images
-    // (fill up entire letter-sized printed page, accounting for print margins)
-    'large' => 18,
-];
-if (empty($sizes[$size])) {
-    throw new InternalException('Invalid size: ' . htmlspecialchars($size) . ' - must be small, medium, or large');
+if (empty($size)) {
+    throw new InternalException('Invalid size passed');
 }
-$multiplier = $sizes[$size];
 
 ?>
 <article class="barcode barcode--<?= $size ?>">
     <h1 class="barcode__title"><?= $details['title'] ?></h1>
     <?php
     /**
-     * SVG Notes:
+     * SVG / Barcode Notes:
      *
-     * Uses pattern:
+     * Uses pattern (5 colors 5 spaces) repeating:
      * | color | space | color | space | color | space | color | space | color | space |
      *
      * Where each color is .2mm wide and each space is .2mm wide.
      *
-     * SVG below uses 10 units = 1mm, so 2 = .2mm
-     *
-     * Barcodes are 5 colors that repeat.
+     * SVG below uses 1 unit = 1mm - if it is scaled differently it will be the wrong size to scan
      */
     ?>
-    <svg class="barcode__pattern" viewBox="0 0 <?= 100 * $multiplier ?> 3000" xmlns="http://www.w3.org/2000/svg">
+    <svg class="barcode__pattern" viewBox="0 0 <?= 10 * $size ?> 300" xmlns="http://www.w3.org/2000/svg">
         <defs>
-            <g stroke-width="2" id="pattern<?= $details['id'] ?>">
+            <g stroke-width=".2" id="pattern<?= $details['id'] ?>">
                 <?php foreach ($details['pattern'] as $lineNum => $color): ?>
-                    <?php $x = ($lineNum * 4) ?>
-                    <line x1="<?= $x ?>" y1="0" x2="<?= $x ?>" y2="100%" stroke="var(--<?= $color ?>)" />
+                    <?php $x = ($lineNum * .4) ?>
+                    <line x1="<?= $x ?>" y1="0" x2="<?= $x ?>" y2="100%" stroke="var(--barcode-<?= $color ?>)" />
                 <?php endforeach; ?>
             </g>
         </defs>
-        <?php for ($i = 0; $i < 5 * $multiplier; $i++): ?>
-            <use href="#pattern<?= $details['id'] ?>" x="<?= $i * 20 + 1 ?>"/>
+        <?php for ($i = 0; $i < 5 * $size; $i++): ?>
+            <use href="#pattern<?= $details['id'] ?>" x="<?= $i * 2 + .1 ?>"/>
         <?php endfor; ?>
     </svg>
 </article>

--- a/webroot/generate.php
+++ b/webroot/generate.php
@@ -2,6 +2,7 @@
 
 use Jonyo\MarioLego\Exception\BadRequestException;
 use Jonyo\MarioLego\Exception\InvalidIdException;
+use Jonyo\MarioLego\Exception\InvalidSizeException;
 use Jonyo\MarioLego\Exception\NotFoundException;
 use Jonyo\MarioLego\Model\Barcode;
 
@@ -87,7 +88,11 @@ if ($showId) {
     $codes = $barcode->appendIdsToTitles($codes);
 }
 
-$size = $_GET['size'] ?? 'small';
+$size = (int)($_GET['size'] ?? 2);
+$sizes = [1,2,6,12,18];
+if (!in_array($size, $sizes)) {
+    throw new InvalidSizeException('Invalid size ' . $size . 'cm, must be one of ' . implode('cm, ', $sizes) . 'cm.');
+}
 ?>
 <!doctype html>
 <html>

--- a/webroot/index.php
+++ b/webroot/index.php
@@ -32,10 +32,12 @@ $named = $barcode->allNamed();
             </label>
             <label>
                 Size:
-                <select name="size">
-                    <option>small</option>
-                    <option>medium</option>
-                    <option value="large">large (full page barcode)</option>
+                <select name="size" size-dropdown>
+                    <option value="1">1cm</option>
+                    <option value="2" selected>2cm</option>
+                    <option value="6">6cm</option>
+                    <option value="12">12cm</option>
+                    <option value="18">18cm (full page)</option>
                 </select>
             </label>
             <input type="submit" value="Generate">

--- a/webroot/style.css
+++ b/webroot/style.css
@@ -1,21 +1,20 @@
 :root {
-    /** Do NOT change - for barcodes **/
-    --red: #b22222;
-    --yellow: #fad700;
-    --light-green: #9acd33;
-    --dark-green: #2e8b57;
-    --teal: #26b2aa;
-    --blue: #4169e1;
-    --purple: #9370db;
-    --pink: #da70d6;
+    --barcode-red: #b22222;
+    --barcode-yellow: #fad700;
+    --barcode-light-green: #9acd33;
+    --barcode-dark-green: #2e8b57;
+    --barcode-teal: #26b2aa;
+    --barcode-blue: #4169e1;
+    --barcode-purple: #9370db;
+    --barcode-pink: #da70d6;
 
-    /** Used by main page **/
+    --teal: #26b2aa;
     --dark-teal: #0b3231;
     --light-teal: #a8ede9;
     --transparent-white: rgba(255, 255, 255, .8);
-    --fire: #b1252c;
-    --light-fire: #f4cbcd;
-    --dark-fire: #4c1013;
+    --red: #b1252c;
+    --light-red: #f4cbcd;
+    --dark-red: #4c1013;
 }
 
 /**
@@ -101,19 +100,19 @@ body {
  */
 
 .error {
-    border: 2px solid var(--dark-fire);
+    border: 2px solid var(--dark-red);
     border-radius: .5rem;
     padding: 1rem;
-    background-color: var(--light-fire);
+    background-color: var(--light-red);
 }
 
 .error__title {
-    color: var(--fire);
+    color: var(--red);
     margin: 0;
 }
 
 .error__message {
-    color: var(--dark-fire);
+    color: var(--dark-red);
 }
 
 /**
@@ -164,17 +163,28 @@ body {
     page-break-inside: avoid;
 }
 
-.barcode--small {
+.barcode--1 {
+    width: 1cm;
+    height: 1cm;
+}
+
+.barcode--2 {
     width: 2cm;
     height: 2cm;
 }
 
-.barcode--medium {
+.barcode--6 {
     width: 6cm;
     height: 6cm;
 }
 
-.barcode--large {
+.barcode--12 {
+    width: 12cm;
+    height: 12cm;
+}
+
+.barcode--18 {
+    /* unlike other sizes, this one is filling entire page */
     width: 18cm;
     height: 24cm;
     display: block;
@@ -197,14 +207,28 @@ body {
     margin: 0;
 }
 
+.barcode--1 .barcode__title {
+    /* Note: use px here, as it will not go below 9px using rem */
+    font-size: 5px;
+    padding: .1rem;
+}
+
 .barcode__pattern {
-    width: 20mm;
+    width: 1cm;
 }
 
-.barcode--medium .barcode__pattern {
-    width: 60mm;
+.barcode--2 .barcode__pattern {
+    width: 2cm;
 }
 
-.barcode--large .barcode__pattern {
-    width: 180mm;
+.barcode--6 .barcode__pattern {
+    width: 6cm;
+}
+
+.barcode--12 .barcode__pattern {
+    width: 12cm;
+}
+
+.barcode--18 .barcode__pattern {
+    width: 18cm;
 }


### PR DESCRIPTION
Closes #12

This changes the size options from small, medium, and large, to: 

* 1cm
* 2cm (previously small)
* 6cm (previously medium)
* 12cm
* 18cm (previously large)

Also in the PR:
* Adjusts the SVG scale to 1 unit = 1mm
* Adds a new `InvalidSizeException` to handle un-configured sizes
* Changes CSS color variable names used for barcode SVG to avoid overlap with vars used for main page