### PR TITLE
Creating way to re-use template output to speed up repeating template…

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types = 1);
 
+use Jonyo\MarioLego\Model\Template;
+
 /**
  * Note: this is a very basic app so this just sets up a very basic framework
  */
@@ -13,8 +15,7 @@ require 'vendor/autoload.php';
  */
 function template(string $name, array $vars = []): void
 {
-    extract($vars);
-    include BASE_DIR . "templates/$name.php";
+    echo Template::getTemplate($name, $vars)->output();
 }
 
 /**

--- a/src/Model/Template.php
+++ b/src/Model/Template.php
@@ -1,0 +1,92 @@
+<?php declare(strict_types = 1);
+
+namespace Jonyo\MarioLego\Model;
+
+use Jonyo\MarioLego\Exception\InternalException;
+
+/**
+ * Template class with built in cache for repeating the same template multiple times
+ */
+class Template {
+    /**
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @var array
+     */
+    private $vars;
+
+    /**
+     * @var string
+     */
+    private $encodedVars;
+
+    /**
+     * @var string
+     */
+    private $output;
+
+    /**
+     * The cached instance of the last template requested
+     *
+     * @var ?\Jonyo\MarioLego\Model\Template
+     */
+    private static $lastTemplate;
+
+    public function __construct(string $name, array $vars = [])
+    {
+        $this->name = $name;
+        $this->vars = $vars;
+        $this->encodedVars = json_encode($vars);
+        $this->output = $this->generateOutput();
+    }
+
+    /**
+     * Get the template, using a cached version of the previous template if the same template requested multiple times
+     *
+     * @throws \Jonyo\MarioLego\Exception\InternalException If cannot find template
+     */
+    public static function getTemplate(string $name, array $vars = []): Template
+    {
+        if (static::$lastTemplate && static::$lastTemplate->isSame($name, $vars)) {
+            return static::$lastTemplate;
+        }
+        static::$lastTemplate = new static($name, $vars);
+        return static::$lastTemplate;
+    }
+
+    /**
+     * Get the template outpet
+     */
+    public function output(): string
+    {
+        return $this->output;
+    }
+
+    /**
+     * Check if this template is the same as the given name and vars
+     */
+    public function isSame(string $name, array $vars): bool
+    {
+        if ($name !== $this->name) {
+            return false;
+        }
+        return json_encode($vars) === $this->encodedVars;
+    }
+
+    /**
+     * Generate the output
+     */
+    private function generateOutput(): string
+    {
+        if (!is_readable(BASE_DIR . "templates/$this->name.php")) {
+            throw new InternalException('Invalid template, could not find template: ' . $this->name);
+        }
+        ob_start();
+        extract($this->vars);
+        require BASE_DIR . "templates/$this->name.php";
+        return ob_get_clean();
+    }
+}

--- a/templates/stats.php
+++ b/templates/stats.php
@@ -1,0 +1,6 @@
+<p class="main__tip">
+    <?php if (!empty($startTime)): ?>
+        <strong>Script Load Time:</strong> <?= round(microtime(true) - $startTime, 5) ?> Seconds<br>
+    <?php endif; ?>
+    <strong>Peak Memory Usage:</strong> <?= round(memory_get_peak_usage() / 1048576, 5) ?>MB
+</p>

--- a/webroot/generate.php
+++ b/webroot/generate.php
@@ -9,6 +9,8 @@ use Jonyo\MarioLego\Model\Barcode;
 
 require '../bootstrap.php';
 
+$startTime = microtime(true);
+
 $barcode = new Barcode();
 
 $codes = [];
@@ -126,5 +128,6 @@ if ($quantity < 1 || $quantity > 99) {
                 <?php template('repeat-barcode', compact('details', 'size')); ?>
             <?php endfor; ?>
         <?php endforeach; ?>
+        <?php template('stats', compact('startTime')); ?>
     </main>
 </body>


### PR DESCRIPTION
…s with same vars

This OOP's the `template()` and builds in "repeat cache" - if the same template with same vars is used multiple times in a row, it will just display a cached copy if the output instead of re-rendering it every time.

Also adds a little info at the bottom of the generate page, I used when testing to see if it actually helped and decided to keep it.  The new stats hides on print.